### PR TITLE
Add pure structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
  "cranelift-entity",
  "fxhash",
  "hashbrown 0.12.3",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "smallvec",
 ]
@@ -809,6 +809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,7 +876,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 name = "folding-tree"
 version = "0.1.0"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -1019,7 +1025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 dependencies = [
  "fallible-iterator",
- "indexmap",
+ "indexmap 1.9.3",
  "stable_deref_trait",
 ]
 
@@ -1041,7 +1047,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1207,6 +1213,16 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -1581,6 +1597,7 @@ dependencies = [
  "derive_more",
  "ena",
  "folding-tree",
+ "indexmap 2.0.0",
  "insta",
  "itertools",
  "la-arena",
@@ -1811,7 +1828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -2135,7 +2152,7 @@ dependencies = [
  "bitvec",
  "bytecheck",
  "hashbrown 0.12.3",
- "indexmap",
+ "indexmap 1.9.3",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -2237,7 +2254,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "hashlink",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "parking_lot",
  "rustc-hash",
@@ -3147,7 +3164,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "derivative",
- "indexmap",
+ "indexmap 1.9.3",
  "js-sys",
  "more-asserts",
  "rustc-demangle",
@@ -3229,7 +3246,7 @@ dependencies = [
  "bytecheck",
  "enum-iterator",
  "enumset",
- "indexmap",
+ "indexmap 1.9.3",
  "more-asserts",
  "rkyv",
  "target-lexicon",
@@ -3250,7 +3267,7 @@ dependencies = [
  "derivative",
  "enum-iterator",
  "fnv",
- "indexmap",
+ "indexmap 1.9.3",
  "lazy_static",
  "libc",
  "mach",
@@ -3269,7 +3286,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "url",
 ]
 

--- a/app/wasm/Cargo.lock
+++ b/app/wasm/Cargo.lock
@@ -317,7 +317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -363,6 +363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,7 +394,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 name = "folding-tree"
 version = "0.1.0"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -418,12 +424,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "hashlink"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -478,7 +490,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -689,6 +711,7 @@ dependencies = [
  "derive_more",
  "ena",
  "folding-tree",
+ "indexmap 2.0.0",
  "itertools",
  "la-arena",
  "miette",
@@ -803,7 +826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -872,7 +895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5811547e7ba31e903fe48c8ceab10d40d70a101f3d15523c847cce91aa71f332"
 dependencies = [
  "countme",
- "hashbrown",
+ "hashbrown 0.12.3",
  "memoffset 0.6.5",
  "rustc-hash",
  "text-size",
@@ -915,7 +938,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "hashlink",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "parking_lot",
  "rustc-hash",
@@ -1279,7 +1302,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
  "regex",
 ]
 

--- a/crates/codegen-viper/src/lower/structs.rs
+++ b/crates/codegen-viper/src/lower/structs.rs
@@ -1,7 +1,9 @@
 use mist_core::{mir, mono::types::Adt, util::IdxWrap};
 use silvers::{
-    expression::{AbstractLocalVar, BinOp, Exp, FieldAccess, LocalVar, PermExp},
-    program::{Field, Predicate},
+    expression::{AbstractLocalVar, BinOp, Exp, FieldAccess, LocalVar, PermExp, QuantifierExp},
+    program::{
+        AnyLocalVarDecl, Domain, DomainAxiom, DomainFunc, Field, Function, LocalVarDecl, Predicate,
+    },
 };
 
 use crate::{
@@ -18,49 +20,219 @@ impl BodyLower<'_> {
         adt: Adt,
         invariants: impl IntoIterator<Item = mir::BlockId>,
     ) -> Result<Vec<ViperItem<VExprId>>> {
-        let mut viper_items = vec![];
-
-        let source = mir::BlockId::from_raw(0.into());
-        let self_var = self.slot_to_var(self_slot)?;
-        let self_var = LocalVar { name: self_var.name, typ: silvers::typ::Type::ref_() };
-        let self_ = self.alloc(source, AbstractLocalVar::LocalVar(self_var.clone()));
-
-        self.pre_unfolded.insert(self_slot.place(self.db, self.ib));
-
-        let field_invs: Vec<_> = adt
-            .fields(self.db)
-            .iter()
-            .map(|&f| {
-                let field_ty = f.ty(self.db);
-                let ty = self.lower_type(field_ty)?;
-                let viper_field =
-                    Field { name: mangle::mangled_adt_field(self.db, adt, f), typ: ty.vty };
-                viper_items.push(ViperItem::Field(viper_field.clone()));
-                let perm = self.alloc(source, PermExp::Full);
-                let field_access = FieldAccess::new(self_, viper_field);
-                let field_perm = self.alloc(source, field_access.clone().access_perm(perm));
-
-                let field_ref = self.alloc(source, field_access.access_exp());
-                Ok(if let (Some(cond), _) = self.ty_to_condition(source, field_ref, field_ty)? {
-                    self.alloc(source, Exp::bin(field_perm, BinOp::And, cond))
-                } else {
-                    field_perm
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let inv_invs: Vec<_> =
-            invariants.into_iter().map(|inv| self.pure_lower(inv)).collect::<Result<_>>()?;
-        let body = field_invs
-            .into_iter()
-            .chain(inv_invs)
-            .reduce(|acc, next| self.alloc(source, Exp::bin(acc, BinOp::And, next)));
-
-        viper_items.push(ViperItem::Predicate(Predicate {
-            name: mangle::mangled_adt(self.db, adt),
-            formal_args: vec![self_var.into()],
-            body,
-        }));
-
-        Ok(viper_items)
+        if adt.is_pure(self.db) {
+            pure_struct(self.db, self, adt, self_slot, invariants)
+        } else {
+            impure_struct(self.db, self, adt, self_slot, invariants)
+        }
     }
+}
+
+fn pure_struct(
+    db: &dyn crate::Db,
+    l: &mut BodyLower,
+    adt: Adt,
+    self_slot: mir::SlotId,
+    invariants: impl IntoIterator<Item = mir::BlockId>,
+) -> Result<Vec<ViperItem<VExprId>>> {
+    let mut viper_items = vec![];
+
+    let self_place = self_slot.place(db, l.ib);
+
+    // TODO: is this really a good source?
+    let source = mir::BlockId::from_raw(0.into());
+    let mut functions = Vec::new();
+    let mut axioms = Vec::new();
+    let adt_ty = l.lower_type(adt.ty(db))?.vty;
+    functions.push(DomainFunc {
+        name: mangle::mangled_adt(db, adt) + "_unsafe_init",
+        formal_args: adt
+            .fields(db)
+            .iter()
+            .map(|f| Ok(AnyLocalVarDecl::UnnamedLocalVarDecl { typ: l.lower_type(f.ty(db))?.vty }))
+            .collect::<Result<_>>()?,
+        typ: adt_ty.clone(),
+        unique: false,
+        interpretation: None,
+    });
+    let self_decl = l.slot_to_decl(self_slot)?;
+    let mut init_vars = vec![self_decl.clone()];
+    let mut init_exps = vec![];
+    let tmp_var = LocalVarDecl::new("tmp".to_string(), adt_ty.clone());
+    let tmp =
+        l.alloc(source, Exp::AbstractLocalVar(AbstractLocalVar::LocalVar(tmp_var.clone().into())));
+    for (f_name, f_typ) in adt
+        .fields(db)
+        .into_iter()
+        .map(|f| {
+            let f_name = mangle::mangled_adt_field(db, adt, f);
+            let f_typ = l.lower_type(f.ty(db))?.vty;
+            Ok((f_name, f_typ))
+        })
+        .collect::<Result<Vec<_>>>()?
+    {
+        functions.push(DomainFunc {
+            name: f_name.clone(),
+            formal_args: vec![AnyLocalVarDecl::LocalVarDecl(self_decl.clone())],
+            typ: f_typ.clone(),
+            unique: false,
+            interpretation: None,
+        });
+
+        let f_fn_tmp = l.alloc(source, Exp::new_func_app(f_name.clone(), vec![tmp]));
+        let f_var = LocalVarDecl::new(f_name + "_", f_typ);
+        init_vars.push(f_var.clone());
+        let f_exp =
+            l.alloc(source, Exp::AbstractLocalVar(AbstractLocalVar::LocalVar(f_var.into())));
+        init_exps.push(l.alloc(source, Exp::eq_cmp(f_fn_tmp, f_exp)));
+    }
+    let fn_tmp_args = init_vars[1..]
+        .iter()
+        .map(|v| {
+            l.alloc(source, Exp::AbstractLocalVar(AbstractLocalVar::LocalVar(v.clone().into())))
+        })
+        .collect();
+    let fn_tmp = l.alloc(
+        source,
+        Exp::new_func_app(mangle::mangled_adt(db, adt) + "_unsafe_init", fn_tmp_args),
+    );
+    let init_exp_body =
+        init_exps.into_iter().reduce(|acc, next| l.alloc(source, Exp::bin(acc, BinOp::And, next)));
+    if let Some(init_exp_body) = init_exp_body {
+        let init_exp = l.alloc(source, Exp::new_let(tmp_var, fn_tmp, init_exp_body));
+        axioms.push(DomainAxiom {
+            name: Some(mangle::mangled_adt(db, adt) + "_init_axiom"),
+            exp: l.alloc(
+                source,
+                Exp::Quantifier(QuantifierExp::Forall {
+                    variables: init_vars.clone(),
+                    triggers: Vec::new(),
+                    exp: init_exp,
+                }),
+            ),
+        });
+    }
+    let mut safe_pres = Vec::new();
+    for inv in invariants {
+        let inv_exp = l.pure_lower(inv)?;
+        let exp = l.alloc(
+            inv,
+            Exp::Quantifier(QuantifierExp::Forall {
+                variables: vec![self_decl.clone()],
+                triggers: Vec::new(),
+                exp: inv_exp,
+            }),
+        );
+        axioms.push(DomainAxiom { name: None, exp });
+
+        let safe = l.begin_scope(|l| {
+            for (adt_field, init_var) in adt.fields(l.db).into_iter().zip(init_vars[1..].iter()) {
+                let field_place = self_place.project_deeper(
+                    l.db,
+                    &[mir::Projection::Field(
+                        adt_field.into_field(db),
+                        adt_field.ty(l.db).ghosted(l.db),
+                    )],
+                );
+                let init_exp = l.alloc(
+                    inv,
+                    Exp::AbstractLocalVar(AbstractLocalVar::LocalVar(init_var.clone().into())),
+                );
+                l.alias(field_place, init_exp);
+            }
+
+            l.pure_lower(inv)
+        })?;
+        safe_pres.push(safe);
+    }
+    viper_items.push(ViperItem::Domain(Domain {
+        name: mangle::mangled_adt(db, adt),
+        functions,
+        axioms,
+        typ_vars: Vec::new(),
+        interpretations: None,
+    }));
+    let post_eq = {
+        let result = l
+            .alloc(source, Exp::AbstractLocalVar(AbstractLocalVar::Result { typ: adt_ty.clone() }));
+        let eq = {
+            let final_args = init_vars[1..]
+                .iter()
+                .map(|v| {
+                    l.alloc(
+                        source,
+                        Exp::AbstractLocalVar(AbstractLocalVar::LocalVar(v.clone().into())),
+                    )
+                })
+                .collect();
+            l.alloc(
+                source,
+                Exp::new_func_app(mangle::mangled_adt(db, adt) + "_unsafe_init", final_args),
+            )
+        };
+        l.alloc(source, Exp::eq_cmp(result, eq))
+    };
+    viper_items.push(ViperItem::Function(Function {
+        name: mangle::mangled_adt(db, adt) + "_init",
+        formal_args: init_vars[1..].to_vec(),
+        typ: adt_ty,
+        pres: safe_pres,
+        posts: vec![post_eq],
+        body: None,
+    }));
+    Ok(viper_items)
+}
+
+fn impure_struct(
+    db: &dyn crate::Db,
+    l: &mut BodyLower,
+    adt: Adt,
+    self_slot: mir::SlotId,
+    invariants: impl IntoIterator<Item = mir::BlockId>,
+) -> Result<Vec<ViperItem<VExprId>>> {
+    let mut viper_items = Vec::new();
+
+    // TODO: is this really a good source?
+    let source = mir::BlockId::from_raw(0.into());
+    let self_var = l.slot_to_var(self_slot)?;
+    let self_var = LocalVar { name: self_var.name, typ: silvers::typ::Type::ref_() };
+    let self_place = self_slot.place(db, l.ib);
+    let self_ = l.alloc(source, AbstractLocalVar::LocalVar(self_var.clone()));
+
+    l.pre_unfolded.insert(self_place);
+
+    let field_invs: Vec<_> = adt
+        .fields(db)
+        .iter()
+        .map(|&f| {
+            let field_ty = f.ty(db);
+            let ty = l.lower_type(field_ty)?;
+            let viper_field = Field { name: mangle::mangled_adt_field(db, adt, f), typ: ty.vty };
+            viper_items.push(ViperItem::Field(viper_field.clone()));
+            let perm = l.alloc(source, PermExp::Full);
+            let field_access = FieldAccess::new(self_, viper_field);
+            let field_perm = l.alloc(source, field_access.clone().access_perm(perm));
+
+            let field_ref = l.alloc(source, field_access.access_exp());
+            Ok(if let (Some(cond), _) = l.ty_to_condition(source, field_ref, field_ty)? {
+                l.alloc(source, Exp::bin(field_perm, BinOp::And, cond))
+            } else {
+                field_perm
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let inv_invs: Vec<_> =
+        invariants.into_iter().map(|inv| l.pure_lower(inv)).collect::<Result<_>>()?;
+    let body = field_invs
+        .into_iter()
+        .chain(inv_invs)
+        .reduce(|acc, next| l.alloc(source, Exp::bin(acc, BinOp::And, next)));
+
+    viper_items.push(ViperItem::Predicate(Predicate {
+        name: mangle::mangled_adt(db, adt),
+        formal_args: vec![self_var.into()],
+        body,
+    }));
+
+    Ok(viper_items)
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,6 +20,7 @@ smol_str.workspace = true
 thiserror.workspace = true
 tracing-test.workspace = true
 tracing.workspace = true
+indexmap = "2.0.0"
 
 [dev-dependencies]
 insta = "1.29.0"

--- a/crates/core/src/def/ext.rs
+++ b/crates/core/src/def/ext.rs
@@ -124,6 +124,9 @@ impl Struct {
     pub fn ast_node(&self, db: &dyn crate::Db) -> ast::Struct {
         self.id(db).to_node(db)
     }
+    pub fn attrs(&self, db: &dyn crate::Db) -> ast::AttrFlags {
+        self.id(db).to_node(db).attr_flags()
+    }
     pub fn name(&self, db: &dyn crate::Db) -> Name {
         self.ast_node(db).name().unwrap().into()
     }

--- a/crates/core/src/hir/item_context/source_map.rs
+++ b/crates/core/src/hir/item_context/source_map.rs
@@ -123,6 +123,9 @@ impl ItemSourceMap {
             self.expr_map_back[expr].span()
         }
     }
+    pub fn expr_ast(&self, ast: SpanOrAstPtr<ast::Expr>) -> Option<ExprIdx> {
+        self.expr_map.get(&ast).copied()
+    }
     pub fn name_var(&self, name: &AstPtr<ast::NameOrNameRef>) -> Option<Named> {
         self.name_map.get(name).cloned()
     }

--- a/crates/core/src/hir/typecheck/expression.rs
+++ b/crates/core/src/hir/typecheck/expression.rs
@@ -150,7 +150,7 @@ fn check_impl(tc: &mut TypeChecker, expr: ast::Expr) -> Either<ExprIdx, Expr> {
                 if let Some(op) = it.op_details() { op } else { todo!("{it:#?}") };
             let inner = check_inner(tc, it);
             let inner_span = tc.expr_span(inner);
-            let inner_ty = tc.expr_ty(inner);
+            let inner_ty = tc.expr_ty(inner).strip_ghost(tc);
 
             let is_ghost = tc.is_ghost(inner);
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,6 +6,8 @@ pub mod file;
 pub mod hir;
 pub mod mir;
 pub mod mono;
+#[cfg(test)]
+pub mod testing;
 pub mod types;
 pub mod util;
 pub mod visit;

--- a/crates/core/src/mir/analysis/liveness.rs
+++ b/crates/core/src/mir/analysis/liveness.rs
@@ -147,19 +147,19 @@ mod tests {
         "#;
         insta::assert_display_snapshot!(generate_annotated_mir(src), @r###"
         :B0
-          {%result: @, %2_x: @}
-        > {%result: @, %2_x: @}
+          {%1_x: @}
+        > {%1_x: @}
           !goto :B1
         :B1
-          {%result: @, %2_x: @}
-        > {%result: @, %2_x: X}
-          %2_x := T { n: $12 }
-          {%result: @, %2_x: { .n X }}
-        > {%result: @, %2_x: { .n X }}
-          assert (== %2_x.n $12)
-          {%result: @, %2_x: X}
-        > {%result: X, %2_x: X}
-          %result := %2_x
+          {%1_x: @}
+        > {%1_x: X}
+          %1_x := T { n: $12 }
+          {%1_x: { .n X }}
+        > {%1_x: { .n X }}
+          assert (== %1_x.n $12)
+          {%result: @, %1_x: X}
+        > {%result: X, %1_x: X}
+          %result := %1_x
         "###)
     }
 
@@ -180,7 +180,7 @@ mod tests {
           {%1_p: { .n X }, %2: @}
         > {%1_p: { .n X }, %2: X}
           %2 := (+ %1_p.n $1)
-          {%1_p: { .n X }, %2: X}
+          {%1_p: { .n @ }, %2: X}
         > {%1_p: { .n X }, %2: X}
           %1_p.n := %2
         "###)
@@ -198,21 +198,21 @@ mod tests {
         "#;
         insta::assert_display_snapshot!(generate_annotated_mir(src), @r###"
         :B0
-          {%1_p: X, %2: @}
-        > {%1_p: X, %2: @}
+          {%1_p: X}
+        > {%1_p: X}
           !goto :B1
         :B1
-          {%1_p: X, %2: @}
-        > {%1_p: { .t X .n X }, %2: @}
+          {%1_p: X}
+        > {%1_p: { .t X }}
           %1_p.t := %1_p
-          {%1_p: { .t { .n X } .n X }, %2: @}
-        > {%1_p: { .t { .n X } .n X }, %2: X}
+          {%1_p: { .t X .n X }, %2: @}
+        > {%1_p: { .t X .n X }, %2: X}
           %2 := (+ %1_p.n $1)
-          {%1_p: { .t { .n X } .n @ }, %2: X}
-        > {%1_p: { .t { .n X } .n X }, %2: X}
+          {%1_p: { .t X .n @ }, %2: X}
+        > {%1_p: { .t X .n X }, %2: X}
           %1_p.n := %2
-          {%1_p: { .t { .n X } .n X }}
-        > {%1_p: { .t { .n X } .n X }}
+          {%1_p: { .t { .n X } .n X }, %2: X}
+        > {%1_p: { .t { .n X } .n X }, %2: X}
           %1_p.t.n := %1_p.n
         "###)
     }
@@ -239,11 +239,11 @@ mod tests {
         > {%1_ts: X, %2: X, %3: @}
           !call %1_ts := (#list %2) -> :B2
         :B2
-          {%1_ts: { [%3] { .n X } }, %3: @}
-        > {%1_ts: { [%3] { .n X } }, %3: X}
+          {%3: @}
+        > {%3: X}
           %3 := $0
-          {%1_ts: { [%3] { .n X } }}
-        > {%1_ts: { [%3] { .n X } }}
+          {%1_ts: { [%3] { .n X } }, %3: @}
+        > {%1_ts: { [%3] { .n X } }, %3: @}
           %1_ts[%3].n := $15
         "###)
     }

--- a/crates/core/src/mir/def/place.rs
+++ b/crates/core/src/mir/def/place.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use itertools::Itertools;
+
 use crate::{
     mono::{
         exprs::{Field, VariablePtr},
@@ -106,6 +108,26 @@ impl Place {
             Projection::Field(_, _) => None,
             Projection::Index(s, ty) => Some(Place::new(s, None, ty)),
         })
+    }
+
+    pub fn display(self, db: &dyn crate::Db) -> String {
+        if !self.has_projection(db) {
+            self.slot().to_string()
+        } else {
+            let projection = self
+                .projection_iter(db)
+                .map(|p| match p {
+                    Projection::Field(f, _) => {
+                        let name = f.name(db);
+                        format!(".{name}")
+                    }
+                    Projection::Index(idx, _) => {
+                        format!("[{idx}]")
+                    }
+                })
+                .format("");
+            format!("{}{}", self.slot(), projection)
+        }
     }
 }
 

--- a/crates/core/src/mono/exprs.rs
+++ b/crates/core/src/mono/exprs.rs
@@ -190,4 +190,7 @@ impl Field {
             Field::Builtin(bf) => bf.name(),
         }
     }
+    pub fn from_adt_field(db: &dyn crate::Db, adt_field: AdtField) -> Field {
+        Field::AdtField(adt_field.adt(db), adt_field)
+    }
 }

--- a/crates/core/src/testing.rs
+++ b/crates/core/src/testing.rs
@@ -1,0 +1,177 @@
+use std::fmt;
+
+use mist_syntax::{ast, AstNode, SyntaxToken};
+
+use crate::{
+    def::{Def, DefKind},
+    file::SourceFile,
+    mono::{
+        lower::MonoDefLower,
+        types::{Adt, Type},
+    },
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Fixture {
+    file: SourceFile,
+    markers: Vec<Marker>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Marker {
+    byte_offset: usize,
+}
+
+impl Fixture {
+    pub fn new(db: &dyn crate::Db, src: impl fmt::Display) -> Fixture {
+        let mut src = src.to_string();
+        let mut markers = Vec::new();
+
+        while let Some((pre, post)) = src.rsplit_once("$0") {
+            markers.push(Marker { byte_offset: pre.len() });
+            src = format!("{pre}{post}")
+        }
+
+        let file = SourceFile::new(db, src);
+
+        Fixture { file, markers }
+    }
+
+    pub fn marker(&self, idx: usize) -> Marker {
+        self.markers[idx]
+    }
+
+    pub fn token_at(&self, db: &dyn crate::Db, m: Marker) -> SyntaxToken {
+        self.file
+            .root(db)
+            .syntax()
+            .token_at_offset(m.byte_offset.try_into().unwrap())
+            .left_biased()
+            .unwrap()
+    }
+
+    pub fn def_at(&self, db: &dyn crate::Db, m: Marker) -> Def {
+        let token = self.token_at(db, m);
+        let item = token.parent_ancestors().find_map(ast::Item::cast).unwrap();
+        let ast_map = self.file.ast_map(db);
+        let ast_id = ast_map.ast_id(self.file, &item);
+        Def::new(db, DefKind::new(db, ast_id).unwrap())
+    }
+
+    pub fn type_at(&self, db: &dyn crate::Db, m: Marker) -> Type {
+        let def = self.def_at(db, m);
+        let hir = def.hir(db).unwrap();
+        let cx = hir.cx(db);
+        let mut mdl = MonoDefLower::new(db, cx);
+
+        let token = self.token_at(db, m);
+
+        if let Some(ty_ast) = token.parent_ancestors().find_map(ast::Type::cast) {
+            let ty_src = hir.source_map(db).ty_ast((&ty_ast).into()).unwrap();
+            mdl.lower_ty(ty_src.ty(db))
+        } else if let Some(expr_ast) = token.parent_ancestors().find_map(ast::Expr::cast) {
+            let expr = hir.source_map(db).expr_ast((&expr_ast).into()).unwrap();
+            let ty_id = cx.expr_ty(expr);
+            mdl.lower_ty(ty_id)
+        } else {
+            todo!()
+        }
+    }
+    pub fn adt_at(&self, db: &dyn crate::Db, m: Marker) -> Adt {
+        self.type_at(db, m).ty_adt(db).unwrap()
+    }
+}
+
+fn fixture(src: impl fmt::Display) -> (crate::db::Database, Fixture) {
+    let db = crate::db::Database::default();
+    let fixture = Fixture::new(&db, src);
+    (db, fixture)
+}
+
+fn check_type_at(src: impl fmt::Display) -> String {
+    let (db, fixture) = fixture(src);
+    let m = fixture.marker(0);
+    fixture.type_at(&db, m).display(&db).to_string()
+}
+
+fn check_pure_type(src: impl fmt::Display) -> Option<bool> {
+    let (db, fixture) = fixture(src);
+    let m = fixture.marker(0);
+    fixture.type_at(&db, m).is_pure(&db)
+}
+
+fn check_pure_adt(src: impl fmt::Display) -> bool {
+    let (db, fixture) = fixture(src);
+    let m = fixture.marker(0);
+    fixture.adt_at(&db, m).is_pure(&db)
+}
+
+#[test]
+fn test_type_at() {
+    insta::assert_display_snapshot!(check_type_at(
+        r#"
+pure struct Pos { x: int }
+invariant Pos$0 { true }
+"#,
+    ), @r#"Pos"#);
+    insta::assert_display_snapshot!(check_type_at(
+        r#"
+pure struct Pos { x: int }
+invariant Pos { self$0.x == 4 }
+"#,
+    ), @r#"ghost Pos"#);
+}
+
+#[test]
+fn test_pure() {
+    assert_eq!(
+        check_pure_type(
+            r#"
+pure struct Pos { x: int }
+invariant Pos$0 { true }
+"#,
+        ),
+        Some(true)
+    );
+    assert_eq!(
+        check_pure_type(
+            r#"
+pure struct Pos { x: int }
+invariant Pos { self$0.x == 4 }
+"#,
+        ),
+        Some(true)
+    );
+    assert_eq!(
+        check_pure_type(
+            r#"
+pure struct Pos[T] { x: T }
+fn f() {
+    let a = Pos$0 { x: 1 };
+}
+"#,
+        ),
+        Some(true)
+    );
+    assert!(check_pure_adt(
+        r#"
+pure struct Pos[T] { x: T }
+fn f() {
+    let a = Pos$0 { x: 1 };
+}
+"#,
+    ));
+    assert!(check_pure_adt(
+        r#"
+pure struct Tuple[T, S] {
+    fst: T,
+    snd: S,
+}
+fn client() {
+    let a = Tuple$0 { fst: 4, snd: 4 };
+    let c = Tuple { fst: a, snd: a };
+    assert sum(c) == 16;
+}
+"#,
+    ));
+}

--- a/crates/core/src/types/data.rs
+++ b/crates/core/src/types/data.rs
@@ -182,6 +182,13 @@ impl AdtKind {
             AdtKind::Enum => todo!(),
         }
     }
+
+    pub fn is_pure(&self, db: &dyn crate::Db) -> bool {
+        match self {
+            AdtKind::Struct(_, s) => s.attrs(db).is_pure(),
+            AdtKind::Enum => todo!(),
+        }
+    }
 }
 
 impl GenericArgs {

--- a/crates/core/src/types/unification.rs
+++ b/crates/core/src/types/unification.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Mutex};
 
 use ena::unify::InPlaceUnificationTable;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use tracing::{debug, info};
 
@@ -56,7 +57,7 @@ pub struct AdtInstantiation {
 
 #[derive(Debug, Default)]
 pub struct AdtPrototypes {
-    data: HashMap<AdtKind, AdtPrototype>,
+    data: IndexMap<AdtKind, AdtPrototype>,
 }
 
 impl AdtPrototypes {
@@ -85,8 +86,8 @@ pub struct Typer {
     ty_cache: HashMap<TypeData, TypeId>,
     ty_keys: Vec<TypeId>,
     adt_prototypes: AdtPrototypes,
-    adt_tys: HashMap<Adt, TypeId>,
-    adt_instantiations: HashMap<Adt, AdtInstantiation>,
+    adt_tys: IndexMap<Adt, TypeId>,
+    adt_instantiations: IndexMap<Adt, AdtInstantiation>,
 }
 
 macro_rules! type_prelude {
@@ -175,7 +176,7 @@ impl Typer {
     ) -> (
         impl Iterator<Item = (TypeId, TypeData)> + '_,
         &AdtPrototypes,
-        &HashMap<Adt, AdtInstantiation>,
+        &IndexMap<Adt, AdtInstantiation>,
     ) {
         (
             self.ty_keys.iter().map(move |&ty| {

--- a/examples/generic-04.mist
+++ b/examples/generic-04.mist
@@ -1,21 +1,24 @@
-// At the time of writing, this is broken to some folding of `let`s, and due to
-// equality of references
-
-struct Tuple[T, S] {
+pure struct Tuple[T, S] {
     fst: T,
     snd: S,
 }
 
-invariant[X] Tuple[X, X] {
+// invariant[X] Tuple[X, X] {
+//     self.fst == self.snd
+// }
+
+invariant Tuple[int, int] {
     self.fst == self.snd
 }
 
-pure fn sum(t: Tuple[&Tuple[int, int], &Tuple[int, int]]) -> int {
+pure fn sum(t: Tuple[Tuple[int, int], Tuple[int, int]]) -> int
+    ens result == 2 * t.fst.snd + 2 * t.snd.snd
+{
     t.fst.fst + t.fst.snd + t.snd.fst + t.snd.snd
 }
 
 fn client() {
     let a = Tuple { fst: 4, snd: 4 };
-    let c = Tuple { fst: &a, snd: &a };
+    let c = Tuple { fst: a, snd: a };
     assert sum(c) == 16;
 }


### PR DESCRIPTION
Pure structs are structs annotated with pure. Their main difference is the way they are lowered, and their semantics.

Comparing pure structs to Rust concepts, they are structs with equality and copy. This inherently means that they cannot be recursive, and must be finite in size.

In Viper, pure structs are lowered as domains, rather than predicates. This also means that they are not subject to folding and unfolding, and their invariants are described using domain axioms, and field access is through domain functions. To make sure that constructed pure structs satisfy their invariants, creating one must go through an abstract function, which checks the invariant as a precondition. This final part is still not quite perfectly implemented.

Additionally, this commit fixes some folding-forrest tests, and begins work for testing with fixtures.

```rs
pure struct Pos {
    x: int,
    z: int,
}

invariant Pos {
    self.x > self.z
}

pure fn pos(x: int, z: int) -> Pos
    req x > z
{
    Pos { x: x, z: z }
}

pure fn add(a: Pos, b: Pos) -> Pos {
    pos(a.x + b.x, a.z + b.z)
}

fn lemma_add_commute(a: Pos, b: Pos)
    ens add(a, b) == add(b, a)
{}
fn lemma_add_assoc(a: Pos, b: Pos, c: Pos)
    ens add(a, add(b, c)) == add(add(a, b), c)
{}
```