### PR TITLE
Exclude WASM from CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,7 @@ jobs:
           tool: just,cargo-nextest
       - name: Tests
         run: |
-          cargo build
-          cargo nextest run --workspace --all
+          cargo nextest run --workspace --exclude mist-codegen-wasm
   fmt:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Building it takes so much time, so lets skip it for now.